### PR TITLE
Add post-start health check

### DIFF
--- a/deployment/operations/enable-post-start-health-check.yml
+++ b/deployment/operations/enable-post-start-health-check.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=etcd/jobs/name=etcd/properties/wait_on_member_health?
+  value: true

--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -8,6 +8,9 @@ properties:
   bootstrap_cluster:
     description: initial deploy option for bootstraping a cluster
     default: false
+  wait_on_member_health:
+    description: enable a post-start health check that checks the health of the member
+    default: false
 
   # Clustering Options
 
@@ -126,8 +129,10 @@ templates:
   peer-ca.crt.erb: config/peer-ca.crt
   peer.crt.erb: config/peer.crt
   peer.key.erb: config/peer.key
+  post-start.erb: bin/post-start
   pre-start.erb: bin/pre-start
   server-ca.crt.erb: config/server-ca.crt
   server.crt.erb: config/server.crt
   server.key.erb: config/server.key
   setup.erb: bin/setup
+  wait-for-member.erb: bin/wait-for-member

--- a/jobs/etcd/templates/etcdctl.erb
+++ b/jobs/etcd/templates/etcdctl.erb
@@ -2,18 +2,24 @@
 
 <% peers = link("etcd_peers") %>
 
+ENDPOINTS="<%= peers.instances.map { |peer| "https://#{peer.address}:#{p("client_port")}" }.join(",") %>"
+
+if [[ "${LOCAL}" -eq "true" ]]; then
+  ENDPOINTS="<%= "https://#{spec.address}:#{p("client_port")}" %>"
+fi
+
 if [[ "${ETCDCTL_API}" -eq "3" ]]; then
   /var/vcap/packages/etcd/etcdctl \
     --cacert /var/vcap/jobs/etcd/config/server-ca.crt \
     --cert /var/vcap/jobs/etcd/config/server.crt \
     --key /var/vcap/jobs/etcd/config/server.key \
-    --endpoints "<%= peers.instances.map { |peer| "https://#{peer.address}:#{p("client_port")}" }.join(",") %>" \
+    --endpoints "${ENDPOINTS}" \
     "$@"
 else
   /var/vcap/packages/etcd/etcdctl \
     --ca-file /var/vcap/jobs/etcd/config/server-ca.crt \
     --cert-file /var/vcap/jobs/etcd/config/server.crt \
     --key-file /var/vcap/jobs/etcd/config/server.key \
-    --endpoints "<%= peers.instances.map { |peer| "https://#{peer.address}:#{p("client_port")}" }.join(",") %>" \
+    --endpoints "${ENDPOINTS}" \
     "$@"
 fi

--- a/jobs/etcd/templates/post-start.erb
+++ b/jobs/etcd/templates/post-start.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+<% if p("wait_on_member_health") %>
+timeout 10m /var/vcap/jobs/etcd/bin/wait-for-member
+<% end %>

--- a/jobs/etcd/templates/wait-for-member.erb
+++ b/jobs/etcd/templates/wait-for-member.erb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+while true; do
+  if ! LOCAL=true ETCDCTL_API=3 /var/vcap/jobs/etcd/bin/etcdctl endpoint health ; then
+    echo "etcd member is not healthy..."
+    sleep 1
+  else
+    echo "etcd member is healthy"
+    exit 0
+  fi
+done


### PR DESCRIPTION
This change adds a post-start script that checks `etcdctl endpoint
health`. It only checks the endpoint health of the local ETCD member.
The `post-start` will timeout if the ETCD member is not healthy within
10 minutes.

This change also adds support for using the `LOCAL=true` environment
variable when calling the helper `etcdctl` script. If this envrionment
variable is set to "true", the `etcdctl` command will only be configured
with the endpoint of the local ETCD member